### PR TITLE
Capture and ignore stderr for `git describe --exact-match`

### DIFF
--- a/git-revision.gemspec
+++ b/git-revision.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name         = 'git-revision'
-  gem.version      = '0.0.4'
+  gem.version      = '0.0.5'
   gem.files        = `git ls-files`.split($\)
   gem.require_path = 'lib'
   gem.license      = 'BSD-2-Clause'

--- a/lib/git-revision.rb
+++ b/lib/git-revision.rb
@@ -1,7 +1,5 @@
 module Git
   class Revision
-    require 'open3'
-
     class << self
       def commit
         `git log -1 --pretty="format:%H"`

--- a/lib/git-revision.rb
+++ b/lib/git-revision.rb
@@ -1,5 +1,7 @@
 module Git
   class Revision
+    require 'open3'
+
     class << self
       def commit
         `git log -1 --pretty="format:%H"`
@@ -22,7 +24,8 @@ module Git
       end
 
       def tag
-        `git describe --exact-match #{commit}`.strip
+        stdout, _stderr, _status = Open3.capture3("git describe --exact-match #{commit}")
+        stdout.strip
       end
 
       def last_tag

--- a/lib/git-revision.rb
+++ b/lib/git-revision.rb
@@ -24,8 +24,7 @@ module Git
       end
 
       def tag
-        stdout, _stderr, _status = Open3.capture3("git describe --exact-match #{commit}")
-        stdout.strip
+        `git tag --points-at #{commit} | sort | head -n 1`.strip
       end
 
       def last_tag


### PR DESCRIPTION
If the current commit has no annotated tag pointing to it, then the command `git describe --exact-match HEAD` will emit a message on STDERR like this one:
```
fatal: no tag exactly matches 'f1e9dd070ecca5e99b0ae5c4e4f14ed2918b03db'
```
This is expected in most situations when running automated tests during development, and clutters up the test logs.

This PR captures and silently discards STDERR for this one command.