### PR TITLE
Add long_tag

### DIFF
--- a/lib/git-revision.rb
+++ b/lib/git-revision.rb
@@ -29,6 +29,10 @@ module Git
         `git describe --tags --abbrev=0`.strip
       end
 
+      def long_tag
+        `git describe --long`.strip
+      end
+
       def branch
         `git rev-parse --abbrev-ref HEAD`.strip
       end
@@ -47,7 +51,8 @@ module Git
           :authored_date      => date,
           :authored_timestamp => timestamp,
           :commit_tag         => tag,
-          :repo_last_tag      => last_tag
+          :repo_last_tag      => last_tag,
+          :long_tag           => long_tag
         }
       end
     end


### PR DESCRIPTION
`git describe --long` provides both the most recent tag and the current short hash, along with the number of commits between the two. This gives a more unequivocal but still human-readable pointer to the current state of the repository. It also avoids the "fatal errors" in CI and increased friction associated with needing to create an annotated tag for every push just to avoid seeing those errors.